### PR TITLE
Fix Windows compilation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,39 +3,35 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    name: Cargo build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --all-features
   test:
-    name: Cargo test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        toolchain: [stable, nightly]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
+
   fmt:
-    name: Cargo fmt
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        toolchain: [stable, nightly]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1
@@ -43,27 +39,18 @@ jobs:
           command: fmt
           args: -- --check
 
-  check:
-    name: Cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-
   clippy:
-    name: Cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        toolchain: [stable, nightly]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ matrix.toolchain }}
           override: true
           components: clippy
       - uses: actions-rs/cargo@v1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,7 +687,7 @@ fn sync_dir(path: &Path) -> std::io::Result<()> {
             .read(true)
             .write(true)
             .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-            .open(path)
+            .open(path)?
             .sync_all()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -677,7 +677,11 @@ fn sync_dir(path: &Path) -> std::io::Result<()> {
     {
         // On windows we must use FILE_FLAG_BACKUP_SEMANTICS to get a handle to the file
         // From: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
-        const FILE_FLAG_BACKUP_SEMANTICS: i32 = 0x02000000;
+        //
+        // Beware that `fs::OpenOptionsExt::custom_flags` takes a `u32` for the Windows
+        // implementation but an `i32` for the unix implementation.
+        // https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags
+        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
         use std::os::windows::fs::OpenOptionsExt;
         fs::OpenOptions::new()
             .read(true)


### PR DESCRIPTION
This PR fixes a couple of compatibility issues on Windows:
1. The [::std::fs::OpenOptionsExt](https://doc.rust-lang.org/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags) is specified to take a `u32` on Windows but was being provided with an `i32`
2. A `?` operator was missing in the Windows implementation of `sync_dir`

Separately, I've converted the exiting GitHub actions CI to run a matrix test across ubuntu, Windows, and macOS to help avoid any platform specific issues in the future.