### PR TITLE
Fix test flakes caused by reliance on system clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,6 @@ zip = { version = "0.6.2", optional = true }
 js-sys = "0.3.64"
 
 [dev-dependencies]
+lazy_static = "1.4.0"
 once_cell = "1.10.0"
+serial_test = "2.0.0"


### PR DESCRIPTION
Replaces #3.

Tests would flake due to changes in the system clock. Many tests were of the form:
1. Record expected timestamp based on system clock
2. Perform file writing action
3. Assert that file with timestamp is on disk

The problem occurred if the system clock rolled over to the next second between 1 and 2.

For deterministic tests, we must use a controlled clock. When running in a unit test context, we therefore swap out the system clock for a mock clock.